### PR TITLE
Indicator as gateway

### DIFF
--- a/IndicatorGateway.js
+++ b/IndicatorGateway.js
@@ -1,63 +1,30 @@
 var indicatorDictionary = require('./indicators/indicatorDictionary.js');
 
-function Indicator(indicatorPackage){
+function indicatorGateway(indicatorPackage){
     
     this.activeIndicators = {};
+    this.exceptions = [];
     
-    this.periodData = [];
-    
-    this.longestPeriod = checkLongestPeriod(indicatorPackage);
-    
-
     for(var indicator in indicatorPackage){
         var obj = indicatorPackage[indicator];
-        console.log(indicator);
         this.activeIndicators[indicator] = new indicatorDictionary[indicator](obj, this);
     }
     
-    console.log(this.activeIndicators);
-    
-    
 }
 
-Indicator.updateIndicators = function(){
-    
+indicatorGateway.prototype.updateIndicators = function(newData){
     for(var indicator in this.activeIndicators){
         try{
-            indicator.update(this);
+            this.activeIndicators[indicator].update(newData);
         } catch(e){
-            console.log(e);
+            this.exceptions.push(e);
+            //console.log(e.message + " " + indicator);
         }
     }
-    
-    
 };
 
-Indicator.periodDataFull = function(){
-    return(this.periodData.length === this.longestPeriod);
+indicatorGateway.createNewIndicator = function(indicator){
+    this.activeIndicators[indicator.name] = new indicatorDictionary[indicator.type](indicator.params, this);
 };
 
-Indicator.addPeriodData = function(newData){
-    if(!this.periodDataFull()){
-        this.periodData.push(newData);
-        this.eventTracker.broadcastEvent(this.name + ' period data added', newData);
-    }
-    else{
-        this.periodData.shift();
-        this.periodData.push(newData);
-        this.eventTracker.broadcastEvent(this.name + ' period data added', newData);
-    }
-    return true;
-};
-
-function checkLongestPeriod(indicatorPackage){
-    var temp = 0;
-    for(var indicator in indicatorPackage){
-        if(indicator.period > temp){
-            temp = indicator.period;
-        }
-    }
-    return temp;
-}
-
-module.exports = Indicator;
+module.exports = indicatorGateway;

--- a/IndicatorGateway.js
+++ b/IndicatorGateway.js
@@ -1,0 +1,63 @@
+var indicatorDictionary = require('./indicators/indicatorDictionary.js');
+
+function Indicator(indicatorPackage){
+    
+    this.activeIndicators = {};
+    
+    this.periodData = [];
+    
+    this.longestPeriod = checkLongestPeriod(indicatorPackage);
+    
+
+    for(var indicator in indicatorPackage){
+        var obj = indicatorPackage[indicator];
+        console.log(indicator);
+        this.activeIndicators[indicator] = new indicatorDictionary[indicator](obj, this);
+    }
+    
+    console.log(this.activeIndicators);
+    
+    
+}
+
+Indicator.updateIndicators = function(){
+    
+    for(var indicator in this.activeIndicators){
+        try{
+            indicator.update(this);
+        } catch(e){
+            console.log(e);
+        }
+    }
+    
+    
+};
+
+Indicator.periodDataFull = function(){
+    return(this.periodData.length === this.longestPeriod);
+};
+
+Indicator.addPeriodData = function(newData){
+    if(!this.periodDataFull()){
+        this.periodData.push(newData);
+        this.eventTracker.broadcastEvent(this.name + ' period data added', newData);
+    }
+    else{
+        this.periodData.shift();
+        this.periodData.push(newData);
+        this.eventTracker.broadcastEvent(this.name + ' period data added', newData);
+    }
+    return true;
+};
+
+function checkLongestPeriod(indicatorPackage){
+    var temp = 0;
+    for(var indicator in indicatorPackage){
+        if(indicator.period > temp){
+            temp = indicator.period;
+        }
+    }
+    return temp;
+}
+
+module.exports = Indicator;

--- a/core/EventTracker.js
+++ b/core/EventTracker.js
@@ -17,7 +17,7 @@ EventTracker.prototype.broadcastEvent = function(eventString, data){
 };
 
 EventTracker.prototype.registerListener = function(eventString, handler, owner, purpose){
-    this.on(eventString,handler);
+    this.on(eventString, handler);
     var obj = {
         listenerOwner : owner,
         listenerPurpose : purpose

--- a/indicators/Indicator.js
+++ b/indicators/Indicator.js
@@ -8,8 +8,6 @@ function Indicator (name, period, eventTracker) {
     this.record = [];
     this.eventTracker = eventTracker;
     
-    
-    
 }
 
 Indicator.prototype.periodDataFull = function() {
@@ -19,12 +17,12 @@ Indicator.prototype.periodDataFull = function() {
 Indicator.prototype.addPeriodData = function(newData) {
     if(!this.periodDataFull()){
         this.periodData.push(newData);
-        this.eventTracker.broadcastEvent(this.name + ' period data added');
+        this.eventTracker.broadcastEvent(this.name + ' period data added', newData);
     }
     else{
         this.periodData.shift();
         this.periodData.push(newData);
-        this.eventTracker.broadcastEvent(this.name + ' period data added');
+        this.eventTracker.broadcastEvent(this.name + ' period data added', newData);
     }
     return true;
 };

--- a/indicators/Rsi.js
+++ b/indicators/Rsi.js
@@ -1,13 +1,8 @@
 function Rsi(params){
     this.name = params.name || "Rsi";
     this.period = params.period;
-    //this.periodData = [];
-    this.record = [];
-    //this.eventTracker = eventTracker;
-    
     this.periodData = [];
-    
-    
+    this.record = [];
 }
 
 Rsi.prototype.update = function(newData){

--- a/indicators/Rsi.js
+++ b/indicators/Rsi.js
@@ -1,24 +1,37 @@
 var Indicator = require('./Indicator.js');
 var util = require('util');
 
-function Rsi(params, gateWay){
-    //this.name = name;
+function Rsi(params){
+    this.name = params.name || "Rsi";
     this.period = params.period;
     //this.periodData = [];
     this.record = [];
     //this.eventTracker = eventTracker;
     
-    this.periodData = gateWay.periodData;
+    this.periodData = [];
     
     
 }
 
-util.inherits(Rsi, Indicator);
-
-Rsi.update = function(gateWay){
-    this.periodData = gateWay.periodData;
+Rsi.prototype.update = function(newData){
+    this.addPeriodData(newData);
     this.calculateRSI();
 }
+
+Rsi.prototype.periodDataFull = function() {
+    return(this.periodData.length === this.period);
+};
+
+Rsi.prototype.addPeriodData = function(newData) {
+    if(!this.periodDataFull()){
+        this.periodData.push(newData);
+    }
+    else{
+        this.periodData.shift();
+        this.periodData.push(newData);
+    }
+    return true;
+};
 
 Rsi.prototype.calculateRSI = function() {
 
@@ -42,24 +55,24 @@ Rsi.prototype.calculateRSI = function() {
         var tempRSI = 100 - (100 / (1 + RS));
         
         if((tempRSI >= 0) && (tempRSI <= 100)){
-            this.addIndicatorValue(tempRSI);
+            this.record.push(tempRSI);
         }else{
-            throw new invalidDataException(tempRSI);
+            throw new invalidDataException(tempRSI, this);
         }
     }else{
-        throw new insufficientDataException(this.period - this.periodData.length);
+        throw new insufficientDataException(this.period - this.periodData.length, this);
     }
 };
 
-function insufficientDataException(numMissing){
+function insufficientDataException(numMissing, owner){
     this.name = 'Insufficient Data Exception';
-    this.message = 'There is insufficient data to calculate the ' + this.name;
+    this.message = 'There is insufficient data to calculate the ' + owner.name;
     this.numMissing = numMissing;
 }
 
-function invalidDataException(invalidData){
+function invalidDataException(invalidData, owner){
     this.name = 'Invalid Data Exception';
-    this.message = 'The value: ' + invalidData + ' is invalid for ' + this.name;
+    this.message = 'The value: ' + invalidData + ' is invalid for ' + owner.name;
 }
 
 

--- a/indicators/Rsi.js
+++ b/indicators/Rsi.js
@@ -1,17 +1,24 @@
 var Indicator = require('./Indicator.js');
 var util = require('util');
 
-function Rsi(name, period, eventTracker){
-    this.name = name;
-    this.period = period;
-    this.periodData = [];
+function Rsi(params, gateWay){
+    //this.name = name;
+    this.period = params.period;
+    //this.periodData = [];
     this.record = [];
-    this.eventTracker = eventTracker;
+    //this.eventTracker = eventTracker;
+    
+    this.periodData = gateWay.periodData;
     
     
 }
 
 util.inherits(Rsi, Indicator);
+
+Rsi.update = function(gateWay){
+    this.periodData = gateWay.periodData;
+    this.calculateRSI();
+}
 
 Rsi.prototype.calculateRSI = function() {
 

--- a/indicators/Rsi.js
+++ b/indicators/Rsi.js
@@ -1,6 +1,3 @@
-var Indicator = require('./Indicator.js');
-var util = require('util');
-
 function Rsi(params){
     this.name = params.name || "Rsi";
     this.period = params.period;

--- a/indicators/Stch.js
+++ b/indicators/Stch.js
@@ -58,14 +58,12 @@ Stch.prototype.addPeriodData = function(newData) {
         this.periodData.push(newData);
         this.isHighestHigh(newData.highBid);
         this.isLowestLow(newData.lowBid);
-        //this.eventTracker.broadcastEvent(this.name + ' period data added');
     }
     else{
         this.periodData.shift();
         this.periodData.push(newData);
         this.isHighestHigh(newData.highBid);
         this.isLowestLow(newData.lowBid);
-        //this.eventTracker.broadcastEvent(this.name + ' period data added');
     }
     return true;
 };

--- a/indicators/Stch.js
+++ b/indicators/Stch.js
@@ -1,26 +1,27 @@
 var Indicator = require('./Indicator.js');
 var util = require('util');
 
-function Stch(name, period, smaPeriod, eventTracker){
-    this.name = name;
-    this.period = period;
-    this.sSmaPeriod = 3 || smaPeriod;
+function Stch(params ,gateWay, smaPeriod){
+    this.period = params.period;
+    this.SmaPeriod = params.smaPeriod || 3;
     this.kRecord = [];
     this.dRecord = [];
     this.periodData = [];
     
     
-    this.eventTracker = eventTracker;
-    
     this.lowestLow = 0;
     this.highestHigh = 0;
+    
 }
 
 util.inherits(Stch, Indicator);
 
 Stch.prototype.calculateStochasticK = function(){
-    if(!this.periodDataFull()){
+    if(this.periodDataFull()){
         var tempSTCHK = ((this.periodData[this.periodData.length -1].closeBid - this.lowestLow)/(this.highestHigh - this.lowestLow) * 100);
+        console.log((this.periodData[this.periodData.length -1].closeBid - this.lowestLow));
+        console.log((this.highestHigh - this.lowestLow));
+    
         if(tempSTCHK > 0 && tempSTCHK < 100){
             this.addIndicatorValue(tempSTCHK);
         }else{
@@ -53,12 +54,12 @@ Stch.prototype.addPeriodData = function(newData) {
         this.periodData.push(newData);
         this.isHighestHigh(newData.highBid);
         this.isLowestLow(newData.lowBid);
-        this.eventTracker.broadcastEvent(this.name + ' period data added');
+        //this.eventTracker.broadcastEvent(this.name + ' period data added');
     }
     else{
         this.periodData.shift();
         this.periodData.push(newData);
-        this.eventTracker.broadcastEvent(this.name + ' period data added');
+        //this.eventTracker.broadcastEvent(this.name + ' period data added');
     }
     return true;
 };
@@ -66,12 +67,14 @@ Stch.prototype.addPeriodData = function(newData) {
 Stch.prototype.isHighestHigh = function(pricePoint){
     if(pricePoint > this.highestHigh){
         this.highestHigh = pricePoint;
+        console.log('New Highest High! : ' + this.highestHigh);
     }
 };
 
 Stch.prototype.isLowestLow = function(pricePoint){
     if(pricePoint < this.lowestLow){
         this.lowestLow = pricePoint;
+        console.log('New Lowest Low! : ' + this.lowestLow);
     }
 };
 

--- a/indicators/Stch.js
+++ b/indicators/Stch.js
@@ -1,6 +1,3 @@
-var Indicator = require('./Indicator.js');
-var util = require('util');
-
 function Stch(params){
     this.name = params.name || "Stch";
     this.period = params.period;

--- a/indicators/indicatorDictionary.js
+++ b/indicators/indicatorDictionary.js
@@ -1,0 +1,4 @@
+module.exports = {
+    Rsi : require('./Rsi.js'),
+    Stch : require('./Stch.js')
+};

--- a/init.js
+++ b/init.js
@@ -78,8 +78,8 @@ function package_data(response_data) {
 	else if (dataObject.candles.length < 5000 && dataObject.granularity === "D"){
 		dataPackage.day = dataObject.candles;
 		console.log("Daily data added");
-		main(dataPackage);
-	//	tests(dataPackage);
+	//	main(dataPackage);
+		tests(dataPackage);
 	}
 	
 }

--- a/tests.js
+++ b/tests.js
@@ -1,7 +1,60 @@
 var Indicator = require('./indicators/Indicator.js');
 var Rsi = require('./indicators/Rsi.js');
 var EventTracker = require('./core/EventTracker.js');
+var Stch = require('./indicators/Stch.js');
 
+var indicatorGateway = require('./IndicatorGateway.js');
+
+var indicatorPackage = {Rsi : {period : 14,
+                  granulatiry : "ok"},
+            Stch : {period : 14
+                    }
+};
+var testGateway = 0;
+
+
+testGateway = new indicatorGateway(indicatorPackage);
+
+//console.log(testGateway.longestPeriod);
+
+
+/*
+module.exports = function(dataPackage){
+    var eT = new EventTracker;
+    var testStch = new Stch('testStch', 14, 3, eT);
+    var exceptionLog = [];
+    var eventCatch = [];
+    
+
+    for(var i = 0; i < 20; i++){
+        testStch.addPeriodData(dataPackage.day[i]);
+            try {
+                testStch.calculateStochasticK();
+            }catch(e){
+                exceptionLog.push(e);
+                //console.log(e);
+            }
+    }
+    
+    
+    console.log('Event Catch : ' + eventCatch.length);
+    console.log('STCH record : ' + testStch.kRecord.length);
+    console.log('STCH Value : ' + testStch.kRecord[0]);
+    console.log('Event Catch value : ' + eventCatch[0]);
+    console.log('Exceptions : ' + exceptionLog[0].message);
+    console.log('Exception : ' + exceptionLog[19].message);
+    console.log(testStch.eventTracker.listeners);
+   
+   
+    
+};
+*/
+
+
+/*
+#############################
+RSI using Event Tracker tests
+#############################
     
     module.exports = function (dataPackage){
         var eT = new EventTracker;
@@ -11,9 +64,12 @@ var EventTracker = require('./core/EventTracker.js');
         
         testRSI.eventTracker.registerListener('new RSI data', function(newRSI){
             eventCatch.push(newRSI);
-        });
+        }, testRSI, 'catch new RSI data');
+        testRSI.eventTracker.registerListener('RSI period data added', function(newData){
+            console.log(newData);
+        }, testRSI, 'catch new RSI period data');
       
-        for(var i = 0; i < dataPackage.day.length; i++){
+        for(var i = 0; i < 20; i++){
             testRSI.addPeriodData(dataPackage.day[i]);
             try {
                 testRSI.calculateRSI();
@@ -25,12 +81,17 @@ var EventTracker = require('./core/EventTracker.js');
         
         console.log('Event Catch : ' + eventCatch.length);
         console.log('RSI record : ' + testRSI.record.length);
+        console.log('RSI Value : ' + testRSI.record[0]);
+        console.log('Event Catch value : ' + eventCatch[0]);
         console.log(testRSI.eventTracker.listeners);
         
         console.log(dataPackage.day[0]);
 };
 
-
+#################################
+End RSI using Event Tracker tests
+#################################
+*/
 
 
 

--- a/tests.js
+++ b/tests.js
@@ -5,6 +5,38 @@ var Stch = require('./indicators/Stch.js');
 
 var indicatorGateway = require('./IndicatorGateway.js');
 
+module.exports = function(dataPackage){
+    
+    var indicatorPackage = {Rsi : {name : 'test RSI', period : 14}, Stch : {name : 'test STCH', period : 14, smaPeriod : 5}};
+    var testGateway = new indicatorGateway(indicatorPackage);
+    
+
+
+    for(var i = 0; i < 200; i++){
+        testGateway.updateIndicators(dataPackage.day[i]);
+    }
+    
+    console.log(testGateway.activeIndicators['Rsi'].record);
+    console.log(testGateway.activeIndicators['Stch'].kRecord);
+    
+    //console.log(testGateway.exceptions);
+
+}
+
+
+
+
+
+
+
+
+
+
+/*
+#############
+indicatorGateway indicator creation tests
+#########################################
+
 var indicatorPackage = {Rsi : {period : 14,
                   granulatiry : "ok"},
             Stch : {period : 14
@@ -15,8 +47,9 @@ var testGateway = 0;
 
 testGateway = new indicatorGateway(indicatorPackage);
 
-//console.log(testGateway.longestPeriod);
+console.log(testGateway);
 
+*/
 
 /*
 module.exports = function(dataPackage){


### PR DESCRIPTION
Implementing Indicator as gateway.

Its best for all indicator params to be determined upfront. This is in line with a web based reporting system. It is possible to add indicators through indicatorGateway.createNewIndicator(), but this should be discouraged. Depends on the application I suppose.

indicatorPackage should be of the form: {[INDICATOR TYPE] : 
{name : [INDICATOR NAME], period : [PERIOD]}} 
where [INDICATOR TYPE] is the dictionary listing of the indicator (in indicatorDictionary), 
[INDICATOR NAME] is an arbitrary name useful for debugging,
[PERIOD] the period.

This can be extended for different indicators. Documentation pertaining to the params of specific indicators should be created.

The argument for createNewIndicator() is slightly different. The form is:
{type: [INDICATOR TYPE], params {INDICATOR PARAMS}}
where [INDICATOR TYPE] is the type from above,
and {INDICATOR PARAMS} is everything else from above.